### PR TITLE
bacon: update fingerprint

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -40,7 +40,7 @@ TARGET_CONTINUOUS_SPLASH_ENABLED := true
 
 ## Use the latest approved GMS identifiers unless running a signed build
 ifneq ($(SIGN_BUILD),true)
-PRODUCT_BUILD_PROP_OVERRIDES += BUILD_FINGERPRINT=oneplus/bacon/A0001:4.4.2/KVT49L/XNPH25R:user/release-keys PRIVATE_BUILD_DESC="bacon-user 4.4.2 KVT49L XNPH25R release-keys"
+PRODUCT_BUILD_PROP_OVERRIDES += BUILD_FINGERPRINT=oneplus/bacon/A0001:5.0.2/LRX22G/YNG1TAS0YL:user/release-keys PRIVATE_BUILD_DESC="bacon-user 5.0.2 LRX22G YNG1TAS0YL release-keys"
 else
 # Signed bacon gets a special boot animation because it's special.
 PRODUCT_BOOTANIMATION := device/oneplus/bacon/bootanimation.zip


### PR DESCRIPTION
delta zips of rom generated by me fail to flash as device tree has this fingerprint, whereas my multirom TWRP has the old one
